### PR TITLE
Add FuncFlow support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ func main() {
 	}
 
 	// Start the runner
-	duration, errored := runner.Run(ctx, f1, f2)
-	fmt.Printf("runner has completed, took %s and %d/2 errored.\n", duration, errored)
+	duration := runner.RunFunc(ctx, f1, f2)
+	fmt.Printf("runner has completed, took %s..\n", duration)
 }
 ```

--- a/funcflow.go
+++ b/funcflow.go
@@ -1,0 +1,19 @@
+package funcrunner
+
+import (
+	"context"
+)
+
+// FuncFlow type
+type FuncFlow interface {
+	// ID returns identifier
+	ID() string
+	// Enabled?
+	Enabled() (bool, string)
+	// PreRun runs prior to Run(context.Context, []interface{}) error
+	PreRun(context.Context) ([]interface{}, error)
+	// Run is the main run func
+	Run(context.Context, []interface{}) ([]interface{}, error)
+	// PostRun runs after Run(context.Context, []interface{}) error
+	PostRun(context.Context, []interface{}) error
+}

--- a/funcrunner_test.go
+++ b/funcrunner_test.go
@@ -2,26 +2,88 @@ package funcrunner_test
 
 import (
 	"context"
-	"sync"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/spider-pigs/funcrunner"
 )
 
-func TestFuncDone(t *testing.T) {
-	var wg sync.WaitGroup
-	wg.Add(1)
-	runner := funcrunner.Runner{}
-	runner.FuncDone = func(f funcrunner.Func, duration time.Duration, err error) {
-		// Checks that this call is done
-		wg.Done()
-	}
-	ctx := context.Background()
-	f := func(ctx context.Context) error {
+var (
+	happyFunc = func(ctx context.Context) error {
 		return nil
 	}
-	runner.Run(ctx, f)
+	sadFunc = func(ctx context.Context) error {
+		return errors.New(":-(")
+	}
+)
 
-	wg.Wait()
+type fflow struct{}
+
+func (fflow fflow) ID() string                                                { return fmt.Sprintf("%T", fflow) }
+func (fflow fflow) Enabled() (bool, string)                                   { return true, "" }
+func (fflow fflow) PreRun(context.Context) ([]interface{}, error)             { return nil, nil }
+func (fflow fflow) Run(context.Context, []interface{}) ([]interface{}, error) { return nil, nil }
+func (fflow fflow) PostRun(context.Context, []interface{}) error              { return nil }
+func (fflow fflow) String() string                                            { return fflow.ID() }
+
+type fflowDisabled struct{}
+
+func (fflow fflowDisabled) ID() string                                                { return fmt.Sprintf("%T", fflow) }
+func (fflow fflowDisabled) Enabled() (bool, string)                                   { return false, "some reason" }
+func (fflow fflowDisabled) PreRun(context.Context) ([]interface{}, error)             { return nil, nil }
+func (fflow fflowDisabled) Run(context.Context, []interface{}) ([]interface{}, error) { return nil, nil }
+func (fflow fflowDisabled) PostRun(context.Context, []interface{}) error              { return nil }
+func (fflow fflowDisabled) String() string                                            { return fflow.ID() }
+
+func TestRunFuncs(t *testing.T) {
+	fcount := 0
+	runner := funcrunner.Runner{}
+	runner.FuncDone = func(f funcrunner.Func, duration time.Duration, err error) {
+		fcount++
+	}
+	ctx := context.Background()
+	funcs := []funcrunner.Func{happyFunc, sadFunc}
+	duration := runner.RunFuncs(ctx, funcs...)
+	if duration == 0 {
+		t.Error("duration should not be 0")
+	}
+	if fcount != len(funcs) {
+		t.Errorf("expected FuncDone to be called %v, but was called %v times.", len(funcs), fcount)
+	}
+}
+
+func TestRunFlows(t *testing.T) {
+	fcount := 0
+	runner := funcrunner.Runner{}
+	runner.FlowDone = func(f funcrunner.FuncFlow, duration time.Duration, err error) {
+		fcount++
+	}
+	ctx := context.Background()
+	flows := []funcrunner.FuncFlow{fflow{}}
+	duration := runner.RunFlows(ctx, flows...)
+	if duration == 0 {
+		t.Error("duration should not be 0")
+	}
+	if fcount != len(flows) {
+		t.Errorf("expected FlowDone to be called %v, but was called %v times.", len(flows), fcount)
+	}
+}
+
+func TestDisabledRunFlows(t *testing.T) {
+	fcount := 0
+	runner := funcrunner.Runner{}
+	runner.FlowDone = func(f funcrunner.FuncFlow, duration time.Duration, err error) {
+		fcount++
+	}
+	ctx := context.Background()
+	flows := []funcrunner.FuncFlow{fflowDisabled{}}
+	duration := runner.RunFlows(ctx, flows...)
+	if duration != 0 {
+		t.Errorf("duration should be 0 but was %v", duration)
+	}
+	if fcount != len(flows) {
+		t.Errorf("expected FlowDone to be called %v, but was called %v times.", len(flows), fcount)
+	}
 }


### PR DESCRIPTION
Add support for running a sequence of funcs as specified
by the FuncFlow interface: PreRun->Run->PostRun

```
* PreRun(context.Context) ([]interface{}, error): runs prior to Run
* Run(context.Context, []interface{}) ([]interface{}, error): is
the main run func.
* PostRun(context.Context, []interface{}) error: runs after Run
```